### PR TITLE
Add support for IAM instance profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,18 @@ Rancher only supports registries that authenticate with a username and password.
 
 ## How to use
 
-Run this container with the following environment variables:
+In order to authenticate with AWS ECR, this Docker container uses the default
+chain of [credential providers](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).
+
+The easiest way to run it is to feed in the following environment variables:
+
 * `AWS_REGION` - the AWS region of the ECR registry
 * `AWS_ACCESS_KEY_ID`
 * `AWS_SECRET_ACCESS_KEY`
+
+If you're using an IAM instance profile, then you only need to specify the region,
+with the `AWS_REGION` environment variable, and the credentials will be
+automatically negotiated.
 
 Add the following labels to the service in Rancher:
 * `io.rancher.container.create_agent: true`

--- a/main.go
+++ b/main.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/rancher/go-rancher/client"
@@ -18,22 +17,16 @@ import (
 
 // Rancher holds the configuration parameters
 type Rancher struct {
-	URL          string
-	AccessKey    string
-	SecretKey    string
-	AWSAccessKey string
-	AWSSecretKey string
-	AWSRegion    string
+	URL       string
+	AccessKey string
+	SecretKey string
 }
 
 func main() {
 	vargs := Rancher{
-		URL:          os.Getenv("CATTLE_URL"),
-		AccessKey:    os.Getenv("CATTLE_ACCESS_KEY"),
-		SecretKey:    os.Getenv("CATTLE_SECRET_KEY"),
-		AWSAccessKey: os.Getenv("AWS_ACCESS_KEY_ID"),
-		AWSSecretKey: os.Getenv("AWS_SECRET_ACCESS_KEY"),
-		AWSRegion:    os.Getenv("AWS_REGION"),
+		URL:       os.Getenv("CATTLE_URL"),
+		AccessKey: os.Getenv("CATTLE_ACCESS_KEY"),
+		SecretKey: os.Getenv("CATTLE_SECRET_KEY"),
 	}
 
 	err := updateEcr(vargs)
@@ -48,15 +41,11 @@ func main() {
 			fmt.Printf("Error updating ECR, %s\n", err)
 		}
 	}
-
 }
 
 func updateEcr(vargs Rancher) error {
 	fmt.Printf("Updating ECR Credentials\n")
-	ecrClient := ecr.New(session.New(&aws.Config{
-		Region:      aws.String(vargs.AWSRegion),
-		Credentials: credentials.NewStaticCredentials(vargs.AWSAccessKey, vargs.AWSSecretKey, ""),
-	}))
+	ecrClient := ecr.New(session.New(), &aws.Config{})
 
 	resp, err := ecrClient.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{})
 	if err != nil {


### PR DESCRIPTION
Hi, this is the first go code I've ever written. It's not pretty, but it adds support for IAM roles. Would this be something you'd be interested in?

I think - but I haven't tried - a better implementation of what I did might be the following:

```go
config := &aws.Config{
    Region: aws.String(vargs.AWSRegion),
}
if len(vargs.AWSAccessKey) != 0 || len(vargs.AWSSecretKey) != 0 {
    config.Credentials = credentials.NewStaticCredentials(vargs.AWSAccessKey, vargs.AWSSecretKey, "")
}

ecrClient := ecr.New(session.New(config))
```

Thank you for writing your code, it helped me out :)