### PR TITLE
Return when we find a configured registry

### DIFF
--- a/main.go
+++ b/main.go
@@ -125,9 +125,9 @@ func updateEcr(vargs Rancher) error {
 			} else {
 				fmt.Printf("Successfully updated credentials %s for registry %s; registry address: %s\n", credential.Id, registry.Id, registryHost)
 			}
-			break
+			return nil
 		}
-		fmt.Printf("Failed to find configured registry to update for URL %s\n", ecrURL)
 	}
+	fmt.Printf("Failed to find configured registry to update for URL %s\n", ecrURL)
 	return nil
 }


### PR DESCRIPTION
Stop trying as soon as we find our ECR registry or complain only if none of the registries match.

fixes #13 